### PR TITLE
Draft: better rounding and ratio comparisons for RAGE

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -11,6 +11,7 @@
   (async (>= v0.13))
   (postgresql (>= 4.5.2))
   (ocurl (>= 0.9.0))
+  owl
   (ssl (= 0.5.7))
   ppx_sexp_conv
   re

--- a/src/analysis.ml
+++ b/src/analysis.ml
@@ -1,0 +1,81 @@
+open Owl_base
+
+let () =
+  (* use a static seed to keep RAGE's results deterministic *)
+  Owl_base_stats_prng.init 42
+
+(* T. Chen et al. Statistical Performance Comparison of Computers. 2012 *)
+let hpt_uni ?alpha ~baseline ~comparison =
+  let open Owl in
+  (* Wilcoxon Rank-Sum Test, a.k.a. Mann-Whitney U-test. *)
+  (Stats.mannwhitneyu ?alpha ~side:Stats.RightSide comparison baseline).reject
+
+let hpt_cross ?alpha ~baseline ~comparison =
+  let open Owl in
+  let is_significant = Array.map2 (fun baseline comparison ->
+      hpt_uni ?alpha ~baseline ~comparison) baseline comparison in
+  let baseline =
+    Array.map2
+      (fun x is -> if is then Stats.median x else 0.)
+      baseline is_significant
+  in
+  let comparison =
+    Array.map2
+      (fun y is -> if is then Stats.median y else 0.)
+      comparison is_significant
+  in
+  fun gamma ->
+    let comparison = Array.map (fun x -> x /. gamma) comparison in
+    (Stats.wilcoxon ?alpha ~side:RightSide comparison baseline).reject
+
+(** [speedup ?r ?gamma ~baseline ~comparison] computes the speedup of [comparison] over [baseline]
+ * at confidence level [r], starting from value [gamma]. *)
+let rec speedup ?r ?(limit = 10.0) ?(gamma = 1.0) baseline comparison =
+  if gamma >= limit then gamma
+  else if hpt_uni ?alpha:r ~comparison:(Array.map (fun x -> x /. gamma) comparison) ~baseline then
+    (* [a] significantly outperforms [b] [gamma] times *)
+    speedup ?r ~limit ~gamma:(gamma +. 0.01) baseline comparison
+  else
+    (* We cannot prove that [a] outperforms [b] [gamma] times at [r] confidence level.
+     * (Although this might just mean that the performance is identical). *)
+    gamma
+
+(** [speedup_cross ?r ?gamma a b] computes the speedup of a over b
+ * at confidence level [r], starting from value [gamma].
+ * Like [speedup], but for multiple benchmarks, e.g. when comparing 2 builds or 2 machines.
+ * *)
+let speedup_cross ?r ?(limit = 10.0) ?(gamma = 1.0) ~baseline ~comparison =
+  if gamma >= limit then gamma
+  else
+    let hpt = hpt_cross ?alpha:r ~baseline ~comparison in
+    let rec loop gamma = if hpt gamma then loop (gamma +. 0.01) else gamma in
+    loop gamma
+
+(* Le Boudec, Jean-Yves. Performance Evaluation of Computer and Communication Systems, 2010 *)
+
+let bootstrap_gen ?(r0 = 25) ?(gamma = 0.95) f t xs =
+  let r = (Float.ceil (float (2 * r0) /. (1. -. gamma)) |> int_of_float) - 1 in
+  let boot_samples = Array.init r (fun _ -> xs |> f |> t) in
+  Array.sort Float.compare boot_samples ;
+  (* percentile bootstrap estimate *)
+  (boot_samples.(r0), t xs, boot_samples.(r + 1 - r0))
+
+let sample xs = Stats.sample xs (Array.length xs)
+
+let sample2 (xs, ys) = (sample xs, sample ys)
+
+(** [bootstrap ?r0 ?gamma t xs] computes the confidence interval at level [gamma] for the
+ * statistic [t]. [xs] are samples from an iid sequence, and [r0] is the algorithm's accuracy
+ * parameter. Does not require the distribution to be normal.
+ *)
+let bootstrap ?gamma t xs = bootstrap_gen ?gamma sample t xs
+
+let bootstrap_mean ?gamma = bootstrap ?gamma Stats.mean
+
+(* T. Kalibera, R. Jones. Quantifying Performance Changes with Effect Size Confidence Intervals. 2012 *)
+
+(** [bootstrap_ratio ?gamma old_ys new_ys] computes the bootstrap confidence interval at level [gamma]
+ * for the ratio of means of two systems *)
+let bootstrap_ratio ?gamma baseline comparison =
+  let ratio (ns, os) = Stats.mean ns /. Stats.mean os in
+  bootstrap_gen ?gamma sample2 ratio (comparison, baseline)

--- a/src/brief_handler.ml
+++ b/src/brief_handler.ml
@@ -982,7 +982,7 @@ in
                      |None->""
                      |Some mb->
                        let (l,ratio,u),speedup = proportion baseline_ms ms mb in
-                       sprintf "<sub>Speedup=%+.1f%%</sub><sub>(%+.1f%%,%+.1f%%)</sub><sub>(%+.0f%%)</sub>" speedup l u ratio
+                       sprintf "<sub>Speedup=%+.0f%%</sub><sub>(%+.0f%%,%+.0f%%)</sub><sub>(%+.0f%%)</sub>" speedup l u ratio
                   ) in
                 let text = sprintf "<span style='color:%s'>%s <br> %s %s</span>" colour avg number_str diff in
                 sprintf "<div onmouseover=\"this.style.backgroundColor='#FC6'\" onmouseout=\"this.style.backgroundColor='white'\" debug_r='%s' debug_c='%s' title='context:\n%s' debug_ms='%s'>%s</div>" debug_r debug_c context debug_ms text

--- a/src/brief_handler.ml
+++ b/src/brief_handler.ml
@@ -771,7 +771,7 @@ in
     (* === output === *)
 
     (* round value f to 4 significant digits *)
-    let round ?(significant_digits=5) f =
+    let round ?(significant_digits=4) f =
       if no_rounding then
         Float.to_string f, f
       else
@@ -787,7 +787,7 @@ in
       let ravg = round avg in
       let avg' = snd ravg in
       let rel = 100.0 *. Float.abs (Owl_base.Stats.std ~mean:avg' xs /. avg') in
-      f2 (round l) ravg (round u) (round rel) (* 95% confidence *)
+      f2 (round l) ravg (round u) (round ~significant_digits:2 rel) (* 95% confidence *)
     in
     (* pretty print a value f and its stddev *)
     let str_of_round xs =

--- a/src/brief_handler.ml
+++ b/src/brief_handler.ml
@@ -784,8 +784,10 @@ in
         f1 (round xs.(0))
       else
       let l, avg, u = Analysis.bootstrap_mean xs in
-      let rel = 100.0 *. Float.abs (Owl_base.Stats.std ~mean:avg xs /. avg) in
-      f2 (round l) (round avg) (round u) (round ~significant_digits:2 rel) (* 95% confidence *)
+      let ravg = round avg in
+      let avg' = snd ravg in
+      let rel = 100.0 *. Float.abs (Owl_base.Stats.std ~mean:avg' xs /. avg') in
+      f2 (round l) ravg (round u) (round ~significant_digits:3 rel) (* 95% confidence *)
     in
     (* pretty print a value f and its stddev *)
     let str_of_round xs =

--- a/src/brief_handler.ml
+++ b/src/brief_handler.ml
@@ -771,7 +771,7 @@ in
     (* === output === *)
 
     (* round value f to 4 significant digits *)
-    let round ?(significant_digits=4) f =
+    let round ?(significant_digits=5) f =
       if no_rounding then
         Float.to_string f, f
       else
@@ -787,7 +787,7 @@ in
       let ravg = round avg in
       let avg' = snd ravg in
       let rel = 100.0 *. Float.abs (Owl_base.Stats.std ~mean:avg' xs /. avg') in
-      f2 (round l) ravg (round u) (round ~significant_digits:3 rel) (* 95% confidence *)
+      f2 (round l) ravg (round u) (round rel) (* 95% confidence *)
     in
     (* pretty print a value f and its stddev *)
     let str_of_round xs =

--- a/src/dune
+++ b/src/dune
@@ -5,4 +5,4 @@
   (:standard -principal -short-paths))
  (preprocess
   (pps ppx_sexp_conv ppx_let))
- (libraries threads.posix core postgresql curl async sql uri str re ssl))
+ (libraries threads.posix core postgresql curl async sql uri str re ssl owl-base owl))


### PR DESCRIPTION
@mg12 related to the papers (http://evaluate.inf.usi.ch/biblio) we discussed over lunch, see src/analysis.ml
I thought about using an implementation of bootstrap from a library, but the only I could find was the BCa variant in Pareto, and that one is not correct: https://github.com/superbobry/pareto/issues/39
I've implemented the simpler percentile based Bootstrap here.

- [x] Do not assume that measurements are normally distributed, use bootstrap for calculating mean and confidence interval for mean instead of prediction interval based on stderr 2 sigma
- [x] Calculate a confidence interval for the performance delta/ratio we report (I think this will be quite useful a lot of times we see X% regression with >X% error/noise in the data itself)
- [x]  Calculate the largest speedup/regression supportable by experimental evidence (using HPT method)
- [] Use a more efficient algorithm for the HPT loop, first try exponential search until we find a condition that is no longer satistifed, then do binary search to narrow down, instead of looping by +1% each time
- [] Use harmonic mean for speeds, we use arithmetic mean for everything currently